### PR TITLE
examples/image.tex: Fix image paths

### DIFF
--- a/examples/image.tex
+++ b/examples/image.tex
@@ -3,7 +3,7 @@
 \section{Generic Images}\label{sec:figures-generic-images}
 \image
 %imgLink
-{image/frame/header}
+{asset/frame/header}
 %caption
 {NAK Logo}
 %label
@@ -11,7 +11,7 @@
 
 \image
 % imgLink
-{image/frame/header}
+{asset/frame/header}
 % caption
 {NAK Logo}
 %subcaption
@@ -22,7 +22,7 @@
 \section{SVG}\label{sec:figures-svg}
 \svg
 % imgLink
-{examples/resources/svg}
+{examples/asset/svg}
 % caption
 {SVG - Grafik}
 % label
@@ -30,7 +30,7 @@
 
 \svg
 % imgLink
-{examples/resources/svg}
+{examples/asset/svg}
 % caption
 {SVG - Grafik}
 % subcaption (optional)
@@ -41,7 +41,7 @@
 \section{Wraps}\label{sec:figurs-wrap}
 \wrap
 %imgLink
-{image/frame/header}
+{asset/frame/header}
 [0.5\linewidth]
 %relativePos
 [l] %REMOVE
@@ -57,7 +57,7 @@ Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod 
 
 \wrap
 % imgLink
-{image/frame/header}
+{asset/frame/header}
 %imgwidth
 [0.5\linewidth]
 %relativePos


### PR DESCRIPTION
Habs in Overleaf getestet, jetzt werden die Bilder richtig angezeigt und die Fehler sind weg