### PR TITLE
Fixed acronym generation for latex 2024

### DIFF
--- a/frame/acronym.tex
+++ b/frame/acronym.tex
@@ -1,12 +1,12 @@
 % Utility command to avoid duplicating the label
 \newcommand{\acr}[2]{
     \lowercase{\def\key{#1}} % Remove the lowercase part if you want to address your glossary label to have the same capitalization as your name (first parameter)
-    \newacronym{\key}{#1}{#2}
+    \newacronym{#1}{#1}{#2}
     % Dynamically create commands as shorthand for gls: \<\key> -> \gls{<\key>}
     \ifcsname\key\endcsname%
         % Do nothing to not override existing commands
     \else%
-        \expandafter\xdef\csname \key\endcsname{\gls{\key}}
+        \expandafter\xdef\csname \key\endcsname{\gls{#1}}
     \fi%
 }
 


### PR DESCRIPTION
Fixes problem with global variable definition and the `\acr` macro.

Now acronyms don't work with the lowercase `\gls{shorthand}` anymore. But the whole idea of this macro is to have the `\shorthand` macro definitions instead.